### PR TITLE
Fix install error.

### DIFF
--- a/Formula/mono@4.8.rb
+++ b/Formula/mono@4.8.rb
@@ -43,7 +43,7 @@ class MonoAT48 < Formula
       --enable-nls=no
     ]
 
-    args << "--build=" + (MacOS.prefer_64_bit? ? "x86_64": "i686") + "-apple-darwin"
+    args << "--build=" + "x86_64" + "-apple-darwin"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
The error message is
Error: An exception occurred within a child process:
  NoMethodError: undefined method `prefer_64_bit?' for OS::Mac:Module